### PR TITLE
feat(validator): Modify getValidatorAppId function

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ const algodClient = new algosdk.Algodv2(
   /** Enter server here */,
   /** Enter port here */
 )
-const validatorAppID = getValidatorAppID("mainnet")
+const validatorAppID = getValidatorAppID("mainnet", "v2")
 ```
 
 Before doing any operations, we need to make sure the account is opted into the Tinyman Validator App:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ const algodClient = new algosdk.Algodv2(
   /** Enter server here */,
   /** Enter port here */
 )
-const validatorAppID = getValidatorAppID("mainnet", "v2")
+const validatorAppID = getValidatorAppID(SupportedNetwork.Mainnet, ContractVersion.V2)
 ```
 
 Before doing any operations, we need to make sure the account is opted into the Tinyman Validator App:

--- a/src/contract/contract.ts
+++ b/src/contract/contract.ts
@@ -14,6 +14,11 @@ interface ValidatorAppSchema {
   numGlobalByteSlices: any;
 }
 
+export enum ContractVersion {
+  V1_1 = "v1_1",
+  V2 = "v2"
+}
+
 export class TinymanContract {
   private poolLogicSigContractTemplate: string;
   private templateVariables: PoolLogicSigVariables;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export {
 
 export {AccountInformationData} from "./util/account/accountTypes";
 
-export {validatorAppSchema} from "./contract/contract";
+export {validatorAppSchema, ContractVersion} from "./contract/contract";
 
 export {
   getValidatorAppID,

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,26 +1,39 @@
 import algosdk, {Algodv2} from "algosdk";
 
+import {ContractVersion} from "./contract/contract";
 import {SignerTransaction, SupportedNetwork} from "./util/commonTypes";
 
 export const OPT_IN_VALIDATOR_APP_PROCESS_TXN_COUNT = 1;
 
-const VALIDATOR_APP_ID: Record<SupportedNetwork, number> = {
-  testnet: 62368684,
-  mainnet: 552635992
+const VALIDATOR_APP_ID: Record<ContractVersion, Record<SupportedNetwork, number>> = {
+  [ContractVersion.V1_1]: {
+    testnet: 62368684,
+    mainnet: 552635992
+  },
+  [ContractVersion.V2]: {
+    //  TODO: update the values when new validator app is deployed
+    testnet: 62368684,
+    mainnet: 552635992
+  }
 };
 
 /**
  * Get the Validator App ID for a network.
  *
- * @param network "mainnet" | "testnet".
- *
+ * @param {SupportedNetwork} network "mainnet" | "testnet".
+ * @param {ContractVersion} version contract version.
  * @returns the Validator App ID
  */
-export function getValidatorAppID(network: SupportedNetwork): number {
-  const id = VALIDATOR_APP_ID[network];
+export function getValidatorAppID(
+  network: SupportedNetwork,
+  contractVersion: ContractVersion
+): number {
+  const id = VALIDATOR_APP_ID[contractVersion][network];
 
   if (!id) {
-    throw new Error(`No Validator App exists for network ${network}`);
+    throw new Error(
+      `No Validator App exists for ${network} network with ${contractVersion} contract version`
+    );
   }
 
   return id;


### PR DESCRIPTION
### Firstly Merge
- #2 , #3


### Description
- `getValidatorAppId` modified to support multiple contract versions
- Added `ContractVersion` enum
- `VALIDATOR_APP_ID` constant updated. (Don't forget the update v2 ids)

### Notes
- [RFC doc](https://www.notion.so/Remove-validatorAppID-as-argument-22b4079018754506a5c7a51f5552c58f)