### PR TITLE
chore(config): Activate "no unused var/imports" rules

### DIFF
--- a/src/util/asset/assetUtils.ts
+++ b/src/util/asset/assetUtils.ts
@@ -1,7 +1,6 @@
 import algosdk from "algosdk";
 
 import {SignerTransaction} from "../commonTypes";
-import {TinymanAnalyticsApiAsset} from "./assetModels";
 import TinymanError from "../error/TinymanError";
 
 export async function generateOptIntoAssetTxns({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,8 +36,8 @@
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noUnusedLocals": true,                /* Report errors on unused locals. */
+    "noUnusedParameters": true,            /* Report errors on unused parameters. */
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
     // "noUncheckedIndexedAccess": true,      /* Include 'undefined' in index signature results */


### PR DESCRIPTION
- I realized we have these disabled. So we don't get an error if a parameter/variable/import is unused.