### PR TITLE
fix(pool-utils/get-pool-reserves): Converse bigint values to string

### DIFF
--- a/src/util/pool/v1_1/index.ts
+++ b/src/util/pool/v1_1/index.ts
@@ -156,7 +156,11 @@ export async function getPoolReserves(
     // @ts-ignore: Type 'number' is not assignable to type 'bigint'
     reserves.issuedLiquidity = Number(reserves.issuedLiquidity);
 
-    throw new Error(`Invalid pool reserves: ${JSON.stringify(reserves)}`);
+    throw new Error(
+      `Invalid pool reserves: ${JSON.stringify(reserves, (_key: string, value: any) =>
+        typeof value === "bigint" ? value.toString() : value
+      )}`
+    );
   }
 
   return reserves;


### PR DESCRIPTION
### Description 
- Added a replacer method to JSON.stringify.
- I could not get why is throwing that error even though we already cast the BigInt values to Number. But I think providing the replacer function will help to get the correct error

### Related Ticket
- [TINY-797](https://linear.app/hipo/issue/TINY-797/bug-pool-page-clicking-on-a-pool-results-in-an-error-message)

### Notes
- I guess we can merge the v2 branch to the main on this repository. WDYT? cc @edizcelik  @jamcry 