### PR TITLE
chore: Update year in license

### DIFF
--- a/.github/workflows/update-copyright-year-in-license.yml
+++ b/.github/workflows/update-copyright-year-in-license.yml
@@ -1,0 +1,16 @@
+name: Update copyright year(s) in license file
+
+on:
+  schedule:
+    - cron: "0 3 1 1 *" # 03:00 AM on January 1
+
+jobs:
+  update-license-year:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: FantasticFiasco/action-update-license-year@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Tinyman
+Copyright (c) 2023 Tinyman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Description
- Updated year in license
- Added a github action the update the license year automatically. It will update the license year on 1 January at 3:00 AM. We can also customize the PR and commit details but I did not do it. Additional information: https://github.com/marketplace/actions/update-license-copyright-year-s